### PR TITLE
Add video locking feature

### DIFF
--- a/app/src/main/java/com/brouken/player/CustomStyledPlayerView.java
+++ b/app/src/main/java/com/brouken/player/CustomStyledPlayerView.java
@@ -36,6 +36,7 @@ public class CustomStyledPlayerView extends StyledPlayerView implements GestureD
     private long seekMax;
     private boolean canBoostVolume = false;
     private boolean canSetAutoBrightness = false;
+    private boolean isGestureLocked = false;
 
     private final float IGNORE_BORDER = Utils.dpToPx(24);
     private final float SCROLL_STEP = Utils.dpToPx(16);
@@ -161,6 +162,9 @@ public class CustomStyledPlayerView extends StyledPlayerView implements GestureD
 
     @Override
     public boolean onScroll(MotionEvent motionEvent, MotionEvent motionEvent1, float distanceX, float distanceY) {
+        if (isGestureLocked)
+            return false;
+
         if (mScaleDetector.isInProgress())
             return false;
 
@@ -256,6 +260,9 @@ public class CustomStyledPlayerView extends StyledPlayerView implements GestureD
 
     @Override
     public boolean onScale(ScaleGestureDetector scaleGestureDetector) {
+        if (isGestureLocked)
+            return false;
+
         if (canScale) {
             final float previousScaleFactor = mScaleFactor;
             mScaleFactor *= scaleGestureDetector.getScaleFactor();
@@ -340,6 +347,10 @@ public class CustomStyledPlayerView extends StyledPlayerView implements GestureD
             videoSurfaceView.setScaleY(scale);
             //videoSurfaceView.animate().setStartDelay(0).setDuration(0).scaleX(scale).scaleY(scale).start();
         }
+    }
+
+    public void setIsGestureLocked(boolean isGestureLocked) {
+        this.isGestureLocked = isGestureLocked;
     }
 
     @Override

--- a/app/src/main/java/com/brouken/player/CustomStyledPlayerView.java
+++ b/app/src/main/java/com/brouken/player/CustomStyledPlayerView.java
@@ -287,6 +287,9 @@ public class CustomStyledPlayerView extends StyledPlayerView implements GestureD
 
     @Override
     public boolean onScaleBegin(ScaleGestureDetector scaleGestureDetector) {
+        if (isGestureLocked)
+            return false;
+
         mScaleFactor = getVideoSurfaceView().getScaleX();
         if (getResizeMode() != AspectRatioFrameLayout.RESIZE_MODE_ZOOM) {
             canScale = false;

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -176,6 +176,8 @@ public class PlayerActivity extends Activity {
 
         ((DoubleTapPlayerView)playerView).setDoubleTapEnabled(false);
 
+        playerView.setIsGestureLocked(mPrefs.isGestureLocked);
+
         // https://github.com/google/ExoPlayer/issues/5765
         CustomDefaultTimeBar timeBar = playerView.findViewById(R.id.exo_progress);
         timeBar.setBufferedColor(0x33FFFFFF);
@@ -276,6 +278,15 @@ public class PlayerActivity extends Activity {
             resetHideCallbacks();
         });
 
+        ImageButton buttonPadlock = new ImageButton(this, null, 0, R.style.ExoStyledControls_Button_Bottom);
+        updateGestureLockedButtonIcon(buttonPadlock, mPrefs.isGestureLocked);
+        buttonPadlock.setOnClickListener(view -> {
+            boolean isGestureLocked = mPrefs.toggleIsGestureLocked();
+            playerView.setIsGestureLocked(isGestureLocked);
+            updateGestureLockedButtonIcon(buttonPadlock, isGestureLocked);
+            resetHideCallbacks();
+        });
+
         int titleViewPadding = getResources().getDimensionPixelOffset(R.dimen.exo_styled_bottom_bar_time_padding);
         FrameLayout centerView = playerView.findViewById(R.id.exo_controls_background);
         titleView = new TextView(this);
@@ -365,6 +376,7 @@ public class PlayerActivity extends Activity {
             controls.addView(buttonPiP);
         }
         controls.addView(buttonRotation);
+        controls.addView(buttonPadlock);
         controls.addView(exoSettings);
 
         exoBasicControls.addView(horizontalScrollView);
@@ -1333,5 +1345,14 @@ public class PlayerActivity extends Activity {
             ((PictureInPictureParams.Builder)mPictureInPictureParamsBuilder).setAspectRatio(rational);
         }
         enterPictureInPictureMode(((PictureInPictureParams.Builder)mPictureInPictureParamsBuilder).build());
+    }
+
+    private void updateGestureLockedButtonIcon(ImageButton buttonPadlock, boolean isGestureLocked) {
+        if (isGestureLocked){
+            buttonPadlock.setImageResource(R.drawable.ic_locked_padlock_24dp);
+        }
+        else {
+            buttonPadlock.setImageResource(R.drawable.ic_unlocked_padlock_24dp);
+        }
     }
 }

--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -1348,7 +1348,7 @@ public class PlayerActivity extends Activity {
     }
 
     private void updateGestureLockedButtonIcon(ImageButton buttonPadlock, boolean isGestureLocked) {
-        if (isGestureLocked){
+        if (isGestureLocked) {
             buttonPadlock.setImageResource(R.drawable.ic_locked_padlock_24dp);
         }
         else {

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -29,6 +29,7 @@ class Prefs {
     private static final String PREF_KEY_SCOPE_URI = "scopeUri";
     private static final String PREF_KEY_ASK_SCOPE = "askScope";
     private static final String PREF_KEY_AUTO_PIP = "autoPiP";
+    private static final String PREF_KEY_GESTURE_LOCKED = "isGestureLocked";
 
     final Context mContext;
     final SharedPreferences mSharedPreferences;
@@ -49,6 +50,7 @@ class Prefs {
     public boolean firstRun = true;
     public boolean askScope = true;
     public boolean autoPiP = false;
+    public boolean isGestureLocked = false;
 
     private LinkedHashMap positions;
 
@@ -82,6 +84,7 @@ class Prefs {
             scopeUri = Uri.parse(mSharedPreferences.getString(PREF_KEY_SCOPE_URI, null));
         askScope = mSharedPreferences.getBoolean(PREF_KEY_ASK_SCOPE, askScope);
         autoPiP = mSharedPreferences.getBoolean(PREF_KEY_AUTO_PIP, autoPiP);
+        isGestureLocked = mSharedPreferences.getBoolean(PREF_KEY_GESTURE_LOCKED, isGestureLocked);
     }
 
     public void updateMedia(final Uri uri, final String type) {
@@ -227,5 +230,13 @@ class Prefs {
         sharedPreferencesEditor.putBoolean(PREF_KEY_AUTO_PIP, autoPiP);
         sharedPreferencesEditor.commit();
         return autoPiP;
+    }
+
+    public boolean toggleIsGestureLocked() {
+        isGestureLocked = !isGestureLocked;
+        final SharedPreferences.Editor sharedPreferencesEditor = mSharedPreferences.edit();
+        sharedPreferencesEditor.putBoolean(PREF_KEY_GESTURE_LOCKED, isGestureLocked);
+        sharedPreferencesEditor.commit();
+        return isGestureLocked;
     }
 }

--- a/app/src/main/res/drawable/ic_locked_padlock_24dp.xml
+++ b/app/src/main/res/drawable/ic_locked_padlock_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM9,6c0,-1.66 1.34,-3 3,-3s3,1.34 3,3v2L9,8L9,6zM18,20L6,20L6,10h12v10zM12,17c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/app/src/main/res/drawable/ic_unlocked_padlock_24dp.xml
+++ b/app/src/main/res/drawable/ic_unlocked_padlock_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6h2c0,-1.66 1.34,-3 3,-3s3,1.34 3,3v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM18,20L6,20L6,10h12v10zM12,17c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2z"
+      android:fillColor="#ffffff"/>
+</vector>


### PR DESCRIPTION
This pull request implements a basic video locking feature to prevent inadvertent scroll gesture (pinch to zoom, horizontal swipe to quickly seek and vertical swipe to change brightness / volume)

If needed, it would be possible to show a toast when the lock button is clicked to explain to the user what it does. But that requires localization.

The padlock icon is from https://fonts.google.com/icons (material design)

Fixes https://github.com/moneytoo/Player/issues/47, https://github.com/moneytoo/Player/issues/28 and https://github.com/moneytoo/Player/issues/1