### PR TITLE
Fix subtitle loading with network URIs

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -1118,7 +1118,7 @@ public class PlayerActivity extends Activity {
             MediaItem.Builder mediaItemBuilder = new MediaItem.Builder()
                     .setUri(mPrefs.mediaUri)
                     .setMimeType(mPrefs.mediaType);
-            if (mPrefs.subtitleUri != null && Utils.fileExists(this, mPrefs.subtitleUri)) {
+            if (mPrefs.subtitleUri != null && (Utils.fileExists(this, mPrefs.subtitleUri) || Utils.isSupportedNetworkUri(mPrefs.subtitleUri))) {
                 MediaItem.SubtitleConfiguration subtitle = SubtitleUtils.buildSubtitle(this, mPrefs.subtitleUri);
                 mediaItemBuilder.setSubtitleConfigurations(Collections.singletonList(subtitle));
             }


### PR DESCRIPTION
When a user switched to another app and switches back, if the activity is still alive, the previously found subtitles (by `searchSubtitles`) won't be loaded because:
1. The player instance is already released in `Activity#onStop`, and `searchSubtitle` are only called when creating the activity or when it receives new intents. But in this situation only `Activity#onStart` would be called.
2. `Activity#onStart` calls `initializePlayer`, which tries to load the previously used `subtitleUri`, but `Utils.fileExists` does not handle HTTP URIs.

This adds a check in `initializePlayer` to try loading subtitles with network URIs.