### PR TITLE
HTTP/2 support with OkHttp

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     def media3_version = '1.0.0-beta03'
     implementation "androidx.media3:media3-session:$media3_version"
     implementation "androidx.media3:media3-datasource:$media3_version"
+    implementation "androidx.media3:media3-datasource-okhttp:$media3_version"
     implementation "androidx.media3:media3-decoder:$media3_version"
     implementation "androidx.media3:media3-common:$media3_version"
     implementation("androidx.media3:media3-exoplayer-dash:$media3_version") {


### PR DESCRIPTION
I extensively use Just Player for streaming DASH and when checking out my server's logs I found out that Player only use HTTP/1.1. HTTP/2 is already widely rolled out and brings many improvements especially on the performance side, so I seek out ways to give HTTP/2 support to Player. I found out that this can be done with changing the network stack, and ExoPlayer upstream provides 2 alternative network stack with HTTP/2 support: OkHttp and Cronet. Since Player already uses OkHttp, I chose to use it.

I use [this guide](https://exoplayer.dev/network-stacks.html) to help me do this change.