### PR TITLE
add "text/*" to supportedMimeTypesVideo in Utils.java

### DIFF
--- a/app/src/main/java/com/brouken/player/Utils.java
+++ b/app/src/main/java/com/brouken/player/Utils.java
@@ -81,6 +81,7 @@ class Utils {
             "video/avi",
             // For remote storages:
             "video/x-m4v", // .m4v
+            "text/*",
     };
     public static final String[] supportedMimeTypesSubtitle = new String[] {
             MimeTypes.APPLICATION_SUBRIP,


### PR DESCRIPTION
The picker intent launched by openFile does not allow the use of document providers that are potentially available on the system. Curiously, the picker intent launched by loadSubtitleFile does.  They are nearly identical code with one exception, they use different EXTRA_MIME_TYPES.  Through investigation, it hs been determined that EXTRA_MIME_TYPES seems to require the mime type "test/*" in order for document providers to be shown.