### PR TITLE
Fix controller not hiding when paused

### DIFF
--- a/app/src/main/java/com/brouken/player/CustomPlayerView.java
+++ b/app/src/main/java/com/brouken/player/CustomPlayerView.java
@@ -189,7 +189,7 @@ public class CustomPlayerView extends PlayerView implements GestureDetector.OnGe
         if (!PlayerActivity.controllerVisibleFully) {
             showController();
             return true;
-        } else if (PlayerActivity.haveMedia && PlayerActivity.player != null && PlayerActivity.player.isPlaying()) {
+        } else if (PlayerActivity.haveMedia && PlayerActivity.player != null) {
             hideController();
             return true;
         }


### PR DESCRIPTION
Controller does not hide when we pause video and I removed that. It can be frustrating when we want to take a quick screenshot or read something in the scene.