### PR TITLE
Allow Exoplayer to invalidate the track selection on capabilities change

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -1185,6 +1185,8 @@ public class PlayerActivity extends Activity {
         }
 
         trackSelector = new DefaultTrackSelector(this);
+        trackSelector.setParameters(trackSelector.buildUponParameters()
+                .setAllowInvalidateSelectionsOnRendererCapabilitiesChange(true));
         if (mPrefs.tunneling) {
             trackSelector.setParameters(trackSelector.buildUponParameters()
                     .setTunnelingEnabled(true)


### PR DESCRIPTION
If the capabilities of a device change, Exoplayer can invalidate the current selection to adhere to the new list of capabilities.

This helps the Nvidia Shield and its content matching refresh rate option because, during the refresh rate switching period, the reported capabilities change. Without this flag, the device could reproduce audio as PCM instead of the expected passthrough.

Addresses https://github.com/moneytoo/Player/issues/635, additional context https://github.com/androidx/media/issues/2258.

To fully fix the Nvidia Shield issue, we also need to bump media3 to the upcoming release (probably 1.8.0-alpha2) because we need https://github.com/androidx/media/commit/f825ad7e476c7190f21ff0bddb8e02ddf9a5a856 and https://github.com/androidx/media/commit/93cf82df151b16b4220d0c9f646abd45a3d1aed5. However that is not a blocker for this PR, and we could just do it when a new release gets tagged.