### PR TITLE
feat: Auto-load option for external subtitles for network videos (#664)

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -1973,7 +1973,7 @@ public class PlayerActivity extends Activity {
         if (mPrefs.mediaUri == null)
             return;
 
-        if (Utils.isSupportedNetworkUri(mPrefs.mediaUri) && Utils.isProgressiveContainerUri(mPrefs.mediaUri)) {
+        if (mPrefs.subtitleAutoSearch && Utils.isSupportedNetworkUri(mPrefs.mediaUri) && Utils.isProgressiveContainerUri(mPrefs.mediaUri)) {
             SubtitleUtils.clearCache(this);
             if (SubtitleFinder.isUriCompatible(mPrefs.mediaUri)) {
                 subtitleFinder = new SubtitleFinder(PlayerActivity.this, mPrefs.mediaUri);

--- a/app/src/main/java/com/brouken/player/Prefs.java
+++ b/app/src/main/java/com/brouken/player/Prefs.java
@@ -47,6 +47,7 @@ class Prefs {
     private static final String PREF_KEY_LANGUAGE_AUDIO = "languageAudio";
     private static final String PREF_KEY_SUBTITLE_STYLE_EMBEDDED = "subtitleStyleEmbedded";
     private static final String PREF_KEY_SUBTITLE_STYLE_BOLD = "subtitleStyleBold";
+    private static final String PREF_KEY_SUBTITLE_AUTO_SEARCH = "subtitleAutoSearch";
 
     public static final String TRACK_DEFAULT = "default";
     public static final String TRACK_DEVICE = "device";
@@ -81,6 +82,7 @@ class Prefs {
     public String languageAudio = TRACK_DEVICE;
     public boolean subtitleStyleEmbedded = true;
     public boolean subtitleStyleBold = false;
+    public boolean subtitleAutoSearch = false;
 
     private LinkedHashMap positions;
 
@@ -130,6 +132,7 @@ class Prefs {
         languageAudio = mSharedPreferences.getString(PREF_KEY_LANGUAGE_AUDIO, languageAudio);
         subtitleStyleEmbedded = mSharedPreferences.getBoolean(PREF_KEY_SUBTITLE_STYLE_EMBEDDED, subtitleStyleEmbedded);
         subtitleStyleBold = mSharedPreferences.getBoolean(PREF_KEY_SUBTITLE_STYLE_BOLD, subtitleStyleBold);
+        subtitleAutoSearch = mSharedPreferences.getBoolean(PREF_KEY_SUBTITLE_AUTO_SEARCH, subtitleAutoSearch);
     }
 
     public void updateMedia(final Context context, final Uri uri, final String type) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,4 +58,7 @@
     <string name="pref_subtitle_style_bold">Bold style</string>
     <string name="pref_subtitle_style_bold_on">Use bold typeface as regular</string>
     <string name="pref_subtitle_style_bold_off">Use default regular typeface</string>
+    <string name="pref_subtitle_autosearch">Guess subtitles from video name</string>
+    <string name="pref_subtitle_autosearch_on">For network videos, try to load subtitles with common names (e.g., video.srt)</string>
+    <string name="pref_subtitle_autosearch_off">Do not guess subtitles from video name</string>
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -62,6 +62,13 @@
             android:summaryOff="@string/pref_subtitle_style_bold_off"
             app:title="@string/pref_subtitle_style_bold" />
 
+        <SwitchPreferenceCompat
+            app:key="subtitleAutoSearch"
+            app:defaultValue="false"
+            android:summaryOn="@string/pref_subtitle_autosearch_on"
+            android:summaryOff="@string/pref_subtitle_autosearch_off"
+            app:title="@string/pref_subtitle_autosearch" />
+
         <Preference
             app:title="@string/pref_captioning_preferences">
             <intent android:action="android.settings.CAPTIONING_SETTINGS" />


### PR DESCRIPTION
Adds a new setting to automatically search for and load subtitles matching the video filename (e.g., video.srt for video.mp4) when playing network videos.

This improves convenience by reducing the need for manual subtitle selection. Disabled by default; can be enabled via a toggle in Subtitles settings.


It's been observed that videos from network load up faster with this option disabled, rather than enabled. The difference is huge, so I considered disabling it by default, I also think there's a room for improvement for that feature when it's enabled.