### PR TITLE
Read embedded title tag instead of always using filename

### DIFF
--- a/app/src/main/java/com/brouken/player/PlayerActivity.java
+++ b/app/src/main/java/com/brouken/player/PlayerActivity.java
@@ -1295,16 +1295,10 @@ public class PlayerActivity extends Activity {
             MediaItem.Builder mediaItemBuilder = new MediaItem.Builder()
                     .setUri(mPrefs.mediaUri)
                     .setMimeType(mPrefs.mediaType);
-            String title;
             if (apiTitle != null) {
-                title = apiTitle;
-            } else {
-                title = Utils.getFileName(PlayerActivity.this, mPrefs.mediaUri);
-            }
-            if (title != null) {
                 final MediaMetadata mediaMetadata = new MediaMetadata.Builder()
-                        .setTitle(title)
-                        .setDisplayTitle(title)
+                        .setTitle(apiTitle)
+                        .setDisplayTitle(apiTitle)
                         .build();
                 mediaItemBuilder.setMediaMetadata(mediaMetadata);
             }
@@ -1426,6 +1420,15 @@ public class PlayerActivity extends Activity {
     }
 
     private class PlayerListener implements Player.Listener {
+        @Override
+        public void onMediaMetadataChanged(MediaMetadata mediaMetadata) {
+            if (mediaMetadata.title != null && mediaMetadata.title.length() > 0) {
+                titleView.setText(mediaMetadata.title);
+            } else if (apiTitle == null) {
+                titleView.setText(Utils.getFileName(PlayerActivity.this, mPrefs.mediaUri));
+            }
+        }
+
         @Override
         public void onAudioSessionIdChanged(int audioSessionId) {
             try {


### PR DESCRIPTION
Right now the player always shows the filename as the title, even when a file has an actual embedded title tag. Artist tags get read fine, so this seemed like it should work the same way for title.

Turns out the issue is in `PlayerActivity.java`. The code was force-setting the title to the filename on the `MediaItem`, which overrides whatever ExoPlayer would've pulled from the file's embedded metadata. Artist wasn't touched anywhere, so it passed through untouched and worked as expected.

This PR:
- Stops forcing the filename into the `MediaItem`'s title/displayTitle unless the title came from an external API caller (in which case that should still win).
- Adds an `onMediaMetadataChanged` callback so the title bar updates once the file's actual tags are parsed, falling back to the filename if there's no title tag.

Tested on a compiled debug build with files that have title tags and files that don't. Both cases work as expected.

One note: I'm not a Java developer, I worked through the specifics of this fix with AI assistance since I don't read Java. The change is small and I tested it on device, but flagging that up front in case it affects how you want to review it.